### PR TITLE
Account for DST when calculating offset

### DIFF
--- a/solar-time.1s.py
+++ b/solar-time.1s.py
@@ -36,8 +36,12 @@ def get_sun_time(today, pos, eq_time, tz):
 
 def print_information():
     today = datetime.datetime.now()
-    day = today.timetuple().tm_yday
-    tz = time.altzone
+    timetuple = today.timetuple()
+    day = timetuple.tm_yday
+    if timetuple.tm_isdst == 1:
+        tz = time.altzone
+    else:
+        tz = time.timezone
     pos = get_position()
     eq_time = get_eq_time(day)
     sun_time = get_sun_time(today, pos, eq_time, tz)


### PR DESCRIPTION
Previously, the plugin assumed all times were DST. This now determines whether or not to use DST for the current time.

Fixes #2.