### PR TITLE
Refer to xbar instead of BitBar

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-bitbar-solar-time
-=================
+solar-time for xbar
+===================
 
 
-A [BitBar](https://github.com/matryer/bitbar) plugin to display the
+An [xbar](https://github.com/matryer/xbar) plugin to display the
 [Apparent Solar Time](https://en.wikipedia.org/wiki/Solar_time#Apparent_solar_time) as a clock in
 macOS menubar
 
@@ -12,7 +12,7 @@ macOS menubar
 Installation
 ------------
 
-- Install [BitBar](https://getbitbar.com/)
-- Copy [`solar-time.1s.py`](https://github.com/XanderLeaDaren/bitbar-solar-time/raw/master/solar-time.1s.py) to your BitBar plugin directory
+- Install [xbar](https://xbarapp.com/)
+- Copy [`solar-time.1s.py`](https://github.com/XanderLeaDaren/bitbar-solar-time/raw/master/solar-time.1s.py) to your xbar plugin directory
 
 Now get the local solar time!


### PR DESCRIPTION
The name has changed, and the links were redirecting or broken, so this fixes that.

It doesn’t modify any code, because xbar is backward compatible, so this will still work for BitBar users.